### PR TITLE
fixed copyright statements

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,15 +1,11 @@
-bytefmt
+Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
 
-Copyright (c) 2014-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+This project contains software that is Copyright (c) 2013-2015 Pivotal Software, Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+This project is licensed to you under the Apache License, Version 2.0 (the "License").
 
-   http://www.apache.org/licenses/LICENSE-2.0
+You may not use this project except in compliance with the License.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+This project may include a number of subcomponents with separate copyright notices
+and license terms. Your use of these subcomponents is subject to the terms and 
+conditions of the subcomponent's license, as noted in the LICENSE file.


### PR DESCRIPTION
Substantial portions of this code came from https://github.com/cloudfoundry/cli/blob/b4755226a2040e22825d0c800756e45baddbfc71/src/cf/commands/application/helpers.go, i.e. copyright Pivotal in 2013. Everything contributed since Jan 2015 is copyright CFF as per the relevant CLAs.