### PR TITLE
bytes: Allow for float byte sizes

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -21,7 +21,7 @@ const (
 	TERABYTE = 1024 * GIGABYTE
 )
 
-var bytesPattern *regexp.Regexp = regexp.MustCompile(`(?i)^(-?\d+)([KMGT]B?|B)$`)
+var bytesPattern *regexp.Regexp = regexp.MustCompile(`(?i)^(-?\d+(?:\.\d+)?)([KMGT]B?|B)$`)
 
 var invalidByteQuantityError = errors.New("Byte quantity must be a positive integer with a unit of measurement like M, MB, G, or GB")
 
@@ -77,8 +77,8 @@ func ToBytes(s string) (uint64, error) {
 		return 0, invalidByteQuantityError
 	}
 
-	value, err := strconv.ParseUint(parts[1], 10, 0)
-	if err != nil || value < 1 {
+	value, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil || value <= 0 {
 		return 0, invalidByteQuantityError
 	}
 
@@ -86,15 +86,15 @@ func ToBytes(s string) (uint64, error) {
 	unit := strings.ToUpper(parts[2])
 	switch unit[:1] {
 	case "T":
-		bytes = value * TERABYTE
+		bytes = uint64(value * TERABYTE)
 	case "G":
-		bytes = value * GIGABYTE
+		bytes = uint64(value * GIGABYTE)
 	case "M":
-		bytes = value * MEGABYTE
+		bytes = uint64(value * MEGABYTE)
 	case "K":
-		bytes = value * KILOBYTE
+		bytes = uint64(value * KILOBYTE)
 	case "B":
-		bytes = value * BYTE
+		bytes = uint64(value * BYTE)
 	}
 
 	return bytes, nil

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -151,6 +151,21 @@ var _ = Describe("bytefmt", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("parses byte amounts that are float (e.g. 5.3KB)", func() {
+			var (
+				bytes uint64
+				err   error
+			)
+
+			bytes, err = ToBytes("13.5KB")
+			Expect(bytes).To(Equal(uint64(13824)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("4.5KB")
+			Expect(bytes).To(Equal(uint64(4608)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("parses byte amounts with long units (e.g MB, GB)", func() {
 			var (
 				bytes uint64


### PR DESCRIPTION
This implements #13 and allows `ToBytes` to accept values with floats. For instance, `16.3KB` and similar.

With this change, all current tests are passed and we add a couple tests to make sure floats won't break later on.