### PR TITLE
Parse binary-prefixed byte values

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -21,7 +21,7 @@ const (
 	TERABYTE = 1024 * GIGABYTE
 )
 
-var bytesPattern *regexp.Regexp = regexp.MustCompile(`(?i)^(-?\d+(?:\.\d+)?)([KMGT]B?|B)$`)
+var bytesPattern *regexp.Regexp = regexp.MustCompile(`(?i)^(-?\d+(?:\.\d+)?)([KMGT]i?B?|B)$`)
 
 var invalidByteQuantityError = errors.New("Byte quantity must be a positive integer with a unit of measurement like M, MB, G, or GB")
 

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -85,6 +85,29 @@ var _ = Describe("bytefmt", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("parses byte amounts with long binary units (e.g MiB, GiB)", func() {
+			var (
+				megabytes uint64
+				err       error
+			)
+
+			megabytes, err = ToMegabytes("5MiB")
+			Expect(megabytes).To(Equal(uint64(5)))
+			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("5mib")
+			Expect(megabytes).To(Equal(uint64(5)))
+			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("2GiB")
+			Expect(megabytes).To(Equal(uint64(2 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("3TiB")
+			Expect(megabytes).To(Equal(uint64(3 * 1024 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("returns an error when the unit is missing", func() {
 			_, err := ToMegabytes("5")
 			Expect(err).To(HaveOccurred())
@@ -185,6 +208,29 @@ var _ = Describe("bytefmt", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			bytes, err = ToBytes("3TB")
+			Expect(bytes).To(Equal(uint64(3 * TERABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("parses byte amounts with long binary units (e.g MiB, GiB)", func() {
+			var (
+				bytes uint64
+				err   error
+			)
+
+			bytes, err = ToBytes("5MiB")
+			Expect(bytes).To(Equal(uint64(5 * MEGABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("5mib")
+			Expect(bytes).To(Equal(uint64(5 * MEGABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("2GiB")
+			Expect(bytes).To(Equal(uint64(2 * GIGABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("3TiB")
 			Expect(bytes).To(Equal(uint64(3 * TERABYTE)))
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
This adds the ability for bytefmt to correctly parse byte values when the caller specifies binary-prefixed byte values (kiB, MiB, etc.). I notice internally you're doing math in terms of base 2 (1KB == 1024 vs. 1000), so this fortunately doesn't require any other changes than making the regexp allow for an `i` to be in the unit prefix.

The impetus for this change is that we use numeral.js in our frontend, and bytefmt in a Golang CLI. Numeral.js makes the distinction between base-10 and base-2 (as in, 1000 is 1KB but <1KiB), and if we use its default value formatting, this change allows users to directly copy a value off the UI and have bytefmt correctly understand it. Without this change, it fails to parse.