### PR TITLE
Add support for Petabyte and Exabyte

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -18,11 +18,15 @@ const (
 	MEGABYTE
 	GIGABYTE
 	TERABYTE
+	PETABYTE
+	EXABYTE
 )
 
 var invalidByteQuantityError = errors.New("byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB")
 
 // ByteSize returns a human-readable byte string of the form 10M, 12.5K, and so forth.  The following units are available:
+//	E: Exabyte
+//	P: Petabyte
 //	T: Terabyte
 //	G: Gigabyte
 //	M: Megabyte
@@ -34,6 +38,12 @@ func ByteSize(bytes uint64) string {
 	value := float64(bytes)
 
 	switch {
+	case bytes >= EXABYTE:
+		unit = "E"
+		value = value / EXABYTE
+	case bytes >= PETABYTE:
+		unit = "P"
+		value = value / PETABYTE
 	case bytes >= TERABYTE:
 		unit = "T"
 		value = value / TERABYTE
@@ -72,6 +82,8 @@ func ToMegabytes(s string) (uint64, error) {
 // MB = M = MiB = 1024 * K
 // GB = G = GiB = 1024 * M
 // TB = T = TiB = 1024 * G
+// PB = P = PiB = 1024 * T
+// EB = E = EiB = 1024 * P
 func ToBytes(s string) (uint64, error) {
 	s = strings.TrimSpace(s)
 	s = strings.ToUpper(s)
@@ -89,6 +101,10 @@ func ToBytes(s string) (uint64, error) {
 	}
 
 	switch multiple {
+	case "E", "EB", "EIB":
+		return uint64(bytes * EXABYTE), nil
+	case "P", "PB", "PIB":
+		return uint64(bytes * PETABYTE), nil
 	case "T", "TB", "TIB":
 		return uint64(bytes * TERABYTE), nil
 	case "G", "GB", "GIB":

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -6,10 +6,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const maxUint64 = ^uint64(0)
+
 var _ = Describe("bytefmt", func() {
 
 	Context("ByteSize", func() {
 		It("Prints in the largest possible unit", func() {
+			Expect(ByteSize(maxUint64)).To(Equal("16E"))
+			Expect(ByteSize(10 * EXABYTE)).To(Equal("10E"))
+			Expect(ByteSize(uint64(10.5 * EXABYTE))).To(Equal("10.5E"))
+
+			Expect(ByteSize(10 * PETABYTE)).To(Equal("10P"))
+			Expect(ByteSize(uint64(10.5 * PETABYTE))).To(Equal("10.5P"))
+
 			Expect(ByteSize(10 * TERABYTE)).To(Equal("10T"))
 			Expect(ByteSize(uint64(10.5 * TERABYTE))).To(Equal("10.5T"))
 
@@ -60,6 +69,14 @@ var _ = Describe("bytefmt", func() {
 			megabytes, err = ToMegabytes("3T")
 			Expect(megabytes).To(Equal(uint64(3 * 1024 * 1024)))
 			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("4P")
+			Expect(megabytes).To(Equal(uint64(4 * 1024 * 1024 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("5E")
+			Expect(megabytes).To(Equal(uint64(5 * 1024 * 1024 * 1024 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("parses byte amounts with long units (e.g MB, GB)", func() {
@@ -83,6 +100,14 @@ var _ = Describe("bytefmt", func() {
 			megabytes, err = ToMegabytes("3TB")
 			Expect(megabytes).To(Equal(uint64(3 * 1024 * 1024)))
 			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("4PB")
+			Expect(megabytes).To(Equal(uint64(4 * 1024 * 1024 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("5EB")
+			Expect(megabytes).To(Equal(uint64(5 * 1024 * 1024 * 1024 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("parses byte amounts with long binary units (e.g MiB, GiB)", func() {
@@ -105,6 +130,14 @@ var _ = Describe("bytefmt", func() {
 
 			megabytes, err = ToMegabytes("3TiB")
 			Expect(megabytes).To(Equal(uint64(3 * 1024 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("4PiB")
+			Expect(megabytes).To(Equal(uint64(4 * 1024 * 1024 * 1024)))
+			Expect(err).NotTo(HaveOccurred())
+
+			megabytes, err = ToMegabytes("5EiB")
+			Expect(megabytes).To(Equal(uint64(5 * 1024 * 1024 * 1024 * 1024)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -172,6 +205,14 @@ var _ = Describe("bytefmt", func() {
 			bytes, err = ToBytes("3T")
 			Expect(bytes).To(Equal(uint64(3 * TERABYTE)))
 			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("4P")
+			Expect(bytes).To(Equal(uint64(4 * PETABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("5E")
+			Expect(bytes).To(Equal(uint64(5 * EXABYTE)))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("parses byte amounts that are float (e.g. 5.3KB)", func() {
@@ -210,6 +251,14 @@ var _ = Describe("bytefmt", func() {
 			bytes, err = ToBytes("3TB")
 			Expect(bytes).To(Equal(uint64(3 * TERABYTE)))
 			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("4PB")
+			Expect(bytes).To(Equal(uint64(4 * PETABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("5EB")
+			Expect(bytes).To(Equal(uint64(5 * EXABYTE)))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("parses byte amounts with long binary units (e.g MiB, GiB)", func() {
@@ -236,6 +285,14 @@ var _ = Describe("bytefmt", func() {
 
 			bytes, err = ToBytes("3TiB")
 			Expect(bytes).To(Equal(uint64(3 * TERABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("4PiB")
+			Expect(bytes).To(Equal(uint64(4 * PETABYTE)))
+			Expect(err).NotTo(HaveOccurred())
+
+			bytes, err = ToBytes("5EiB")
+			Expect(bytes).To(Equal(uint64(5 * EXABYTE)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
Since the datatype of bytes is always uint64, this can handle utpo 18446744073709551615 Bytes.
Converting this number in "human-readable byte string" format it gives 16777216T.
This can be further Reduced up to Exabytes.

Changes committed:
	modified:   bytes.go

Fixes https://github.com/cloudfoundry/bytefmt/issues/22

Signed-off-by: Abhishek Kashyap <avskksyp@gmail.com>